### PR TITLE
Feat/matchbox cpt

### DIFF
--- a/wp-content/mu-plugins/matchbox-autoloader.php
+++ b/wp-content/mu-plugins/matchbox-autoloader.php
@@ -1,0 +1,2 @@
+<?php
+require_once WPMU_PLUGIN_DIR . '/matchbox-cpt/matchbox-cpt.php';

--- a/wp-content/mu-plugins/matchbox-cpt/matchbox-cpt.php
+++ b/wp-content/mu-plugins/matchbox-cpt/matchbox-cpt.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name: Matchbox CPT
+ * Description: Registers custom post types and taxonomies for Matchbox projects.
+ * Version: 1.0.0
+ * Author: Matchbox
+ * Author URI: https://github.com/matchboxdesigngroup
+ * License: GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+/**
+ * Registers custom post types by including PHP files located in the `post-types` directory of the plugin.
+ *
+ * @since 1.0.0
+ */
+function matchbox_cpt_register_post_types() {
+	/**
+	 * The directory path where the post type PHP files are located.
+	 *
+	 * @var string $dir_path
+	 */
+	$dir_path = plugin_dir_path( __FILE__ ) . 'post-types/';
+
+	/**
+	 * An array of post type PHP files in the `post-types` directory.
+	 *
+	 * @var array $post_types
+	 */
+	$post_types = glob( $dir_path . '*.php' );
+
+	// Loop through each post type PHP file and include it to register the custom post type.
+	foreach ( $post_types as $post_type ) {
+		include $post_type;
+	}
+}
+add_action( 'init', 'matchbox_cpt_register_post_types' );

--- a/wp-content/mu-plugins/matchbox-cpt/matchbox-cpt.php
+++ b/wp-content/mu-plugins/matchbox-cpt/matchbox-cpt.php
@@ -29,8 +29,19 @@ function matchbox_cpt_register_post_types() {
 	 */
 	$post_types = glob( $dir_path . '*.php' );
 
+  /**
+	 * An array of post types to exclude from registration.
+	 *
+	 * @var array $exclude_post_types
+	 */
+	$exclude_post_types = array( 'post', 'page' ); // Example array of post types to exclude. Change this as needed.
+
 	// Loop through each post type PHP file and include it to register the custom post type.
 	foreach ( $post_types as $post_type ) {
+    $post_type_slug = basename( $post_type, '.php' );
+		if ( in_array( $post_type_slug, $exclude_post_types ) ) {
+			continue; // Skip this post type if it's in the exclude array.
+		}
 		include $post_type;
 	}
 }

--- a/wp-content/mu-plugins/matchbox-cpt/post-types/faq.php
+++ b/wp-content/mu-plugins/matchbox-cpt/post-types/faq.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Register custom post type for FAQs.
+ * 
+ * @since 1.0.0
+ * @return void
+ */
+function matchbox_cpt_register_faq_post_type() {
+
+  /**
+   * Set the labels for FAQs post type.
+   * 
+   * @since 1.0.0
+   */
+  $labels = array(
+    'name'                     => __( 'FAQs', 'matchbox' ),
+    'singular_name'            => __( 'FAQ', 'matchbox' ),
+    'add_new'                  => __( 'Add New', 'matchbox' ),
+    'add_new_item'             => __( 'Add New FAQ', 'matchbox' ),
+    'edit_item'                => __( 'Edit FAQ', 'matchbox' ),
+    'new_item'                 => __( 'New FAQ', 'matchbox' ),
+    'view_item'                => __( 'View FAQ', 'matchbox' ),
+    'view_items'               => __( 'View FAQs', 'matchbox' ),
+    'search_items'             => __( 'Search FAQs', 'matchbox' ),
+    'not_found'                => __( 'No FAQs found.', 'matchbox' ),
+    'not_found_in_trash'       => __( 'No FAQs found in Trash.', 'matchbox' ),
+    'parent_item_colon'        => __( 'Parent FAQs:', 'matchbox' ),
+    'all_items'                => __( 'All FAQs', 'matchbox' ),
+    'archives'                 => __( 'FAQ Archives', 'matchbox' ),
+    'attributes'               => __( 'FAQ Attributes', 'matchbox' ),
+    'insert_into_item'         => __( 'Insert into FAQ', 'matchbox' ),
+    'uploaded_to_this_item'    => __( 'Uploaded to this FAQ', 'matchbox' ),
+    'featured_image'           => __( 'Featured Image', 'matchbox' ),
+    'set_featured_image'       => __( 'Set featured image', 'matchbox' ),
+    'remove_featured_image'    => __( 'Remove featured image', 'matchbox' ),
+    'use_featured_image'       => __( 'Use as featured image', 'matchbox' ),
+    'menu_name'                => __( 'FAQs', 'matchbox' ),
+    'filter_items_list'         => __( 'Filter FAQ list', 'matchbox' ),
+    'filter_by_date'            => __( 'Filter by date', 'matchbox' ),
+    'items_list_navigation'    => __( 'FAQs list navigation', 'matchbox' ),
+    'items_list'               => __( 'FAQs list', 'matchbox' ),
+    'item_published'           => __( 'FAQ published.', 'matchbox' ),
+    'item_published_privately' => __( 'FAQ published privately.', 'matchbox' ),
+    'item_reverted_to_draft'   => __( 'FAQ reverted to draft.', 'matchbox' ),
+    'item_scheduled'           => __( 'FAQ scheduled.', 'matchbox' ),
+    'item_updated'             => __( 'FAQ updated.', 'matchbox' ),
+    'item_link'                => __( 'FAQ Link', 'matchbox' ),
+    'item_link_description'    => __( 'A link to an FAQ.', 'matchbox' ),
+  );
+
+  /**
+   * Set the arguments for FAQs post type.
+   * 
+   * @since 1.0.0
+   */
+  $args = array(
+    'labels'                => $labels,
+    'description'           => __( 'Organize and manage frequently asked questions', 'matchbox' ),
+    'public'                => false,
+    'hierarchical'          => false,
+    'exclude_from_search'   => true,
+    'publicly_queryable'    => false,
+    'show_ui'               => true,
+    'show_in_menu'          => true,
+    'show_in_nav_menus'     => false,
+    'show_in_admin_bar'     => false,
+    'show_in_rest'          => true,
+    'menu_position'         => null,
+    'menu_icon'             => 'dashicons-help',
+    'capability_type'       => 'post',
+    'capabilities'          => array(),
+    'supports'              => array( 'title', 'editor', 'revisions' ),
+    'taxonomies'            => array(),
+    'has_archive'           => false,
+    'rewrite'               => array( 'slug' => 'faqs' ),
+    'query_var'             => true,
+    'can_export'            => true,
+    'delete_with_user'      => false,
+    'template'              => array(),
+    'template_lock'         => false,
+  );
+
+  /**
+   * Registers the custom post type.
+   * @param string $post_type Name of the post type. Max length of 20 characters. No capital letters or spaces.
+   * @param array $args Array of arguments for registering a custom post type.
+   * 
+   * @since 1.0.0
+   * @return void
+   */
+  register_post_type( 'matchbox_faq', $args );
+}
+add_action( 'init', 'matchbox_cpt_register_faq_post_type' );
+
+/**
+ * Register the Categories taxonomy for the FAQs post type.
+ * 
+ * @since 1.0.0
+ * @return void
+ */
+function matchbox_cpt_register_faq_taxonomy() {
+
+  /**
+   * Set the labels for FAQs taxonomy.
+   * 
+   * @since 1.0.0
+   */
+  $labels = array(
+    'name'                       => __( 'Categories', 'matchbox' ),
+    'singular_name'              => __( 'Category', 'matchbox' ),
+    'search_items'               => __( 'Search Categories', 'matchbox' ),
+    'popular_items'              => __( 'Popular Categories', 'matchbox' ),
+    'all_items'                  => __( 'All Categories', 'matchbox' ),
+    'parent_item'                => __( 'Parent Category', 'matchbox' ),
+    'parent_item_colon'          => __( 'Parent Category:', 'matchbox' ),
+    'edit_item'                  => __( 'Edit Category', 'matchbox' ),
+    'update_item'                => __( 'Update Category', 'matchbox' ),
+    'add_new_item'               => __( 'Add New Category', 'matchbox' ),
+    'new_item_name'              => __( 'New Category Name', 'matchbox' ),
+    'separate_items_with_commas' => __( 'Separate categories with commas', 'matchbox' ),
+    'add_or_remove_items'        => __( 'Add or remove categories', 'matchbox' ),
+    'choose_from_most_used'      => __( 'Choose from the most used categories', 'matchbox' ),
+    'not_found'                  => __( 'No categories found.', 'matchbox' ),
+    'menu_name'                  => __( 'Categories', 'matchbox' ),
+  );
+
+  /**
+   * Set the arguments for FAQs taxonomy.
+   * 
+   * @since 1.0.0
+   */
+  $args = array(
+    'labels'                     => $labels,
+    'hierarchical'               => true,
+    'public'                     => false,
+    'show_ui'                    => true,
+    'show_admin_column'          => true,
+    'show_in_nav_menus'          => false,
+    'show_tagcloud'              => false,
+    'show_in_rest'               => true,
+    'rewrite'                    => array( 'slug' => 'faq-categories' ),
+  );
+
+  /**
+   * Registers the custom taxonomy for the "matchbox_faq" post type.
+   * @param string $taxonomy Name of the custom taxonomy.
+   * @param string|array $object_type Name of the custom post type or array of post types.
+   * @param array $args Array of arguments for registering the custom taxonomy.
+   * 
+   * @since 1.0.0
+   * @return void
+*/
+  register_taxonomy( 'matchbox_faq_category', 'matchbox_faq', $args );
+}
+add_action( 'init', 'matchbox_cpt_register_faq_taxonomy' );


### PR DESCRIPTION
## Changes proposed in this pull request

This pull request adds Matchbox CPT, a must-use plugin for registering the custom post types. 

## Purpose

### Reason for must-use plugin vs registering in the theme

According to [WordPress documentation](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/), It is considered better to register custom post types in a plugin rather than a theme for several reasons:

- Portability: If you register custom post types in a plugin, you can easily transfer them to a new theme if you decide to change the look of your website. This is because plugins are separate from the theme, so the custom post types will not be lost when you switch themes.
- Separation of concerns: Themes should be focused on presentation, while plugins should be focused on functionality. By registering custom post types in a plugin, you keep the functionality separate from the presentation, making it easier to maintain and update both.
- Reusability: If you create a custom post type in a plugin, you can reuse it on multiple websites without having to recreate it each time. This saves time and effort.
- Security: By registering custom post types in a plugin, you can ensure that only users with the appropriate permissions can access and modify them. This helps to prevent unauthorized access and data breaches.

Overall, registering custom post types in a plugin provides greater flexibility, portability, and security than registering them in a theme.

### Autoloader

This code includes the file matchbox-cpt.php located in the mu-plugins directory. It is required because plugin directories inside the mu-plugin directory will not be loaded automatically by WordPress.

### Matchbox CPT plugin

This code registers the plugin and its basic functionality.

Features: 
- Registers custom post types by looping through PHP files located in the `post-types` directory of the plugin.
- Adds `$exclude_post_types array` variable to specify post types to exclude from registration.
- The code has been documented with PHPDoc comments for clarity and ease of understanding.

### FAQs post type

This code registers a custom post type for Frequently Asked Questions (FAQs) along with a Categories taxonomy for the FAQs post type. The custom post type allows users to organize and manage FAQs.

Features:

- Set the labels for FAQs post type to define names, slug, and other terms related to the FAQs.
- Set the arguments for FAQs post type, which includes the post type labels, descriptions, supports, taxonomies, menu icon, and rewrite rules.
- Register the custom post type "matchbox_faq" using the register_post_type() function.
- Set the labels for FAQs taxonomy, which includes the taxonomy names, singular name, menu name, search name, and add new item name.
- Register the categories taxonomy for the FAQs post type using the register_taxonomy() function.
- The code has been documented with PHPDoc comments for clarity and ease of understanding.

## Pre-submit checklist

As the author of this pull request, I verify that:

- [ ] I have set the target branch to `master`.
- [ ] I have detailed the purpose of this Pull Request in a non-technical way.
- [ ] I have detailed how to test the changes in the Pull Request.
- [ ] I have detailed the functional tests required for approval.
- [ ] I have self-reviewed my code to ensure it is DRY and follows the team's coding standards.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have verified that my code does not introduce a debug warning in my local environment.
- [ ] I have verified that the functional tests work in my local environment.
- [ ] I have verified that all automated tests pass or have provided a detailed comment about why I submit with a failed pipeline.
- [ ] I have verified that any dependent changes have been merged and published in downstream commits.
- [ ] I have added a link to this Pull Request in the Asana task.
- [ ] I have moved the Asana task to "Ready for Functional Review".
- [ ] I have left a comment in Asana and GitHub tagging a team member with a request for `review.

## Testing

### How to test the changes in this pull request

<!-- Add the steps that should be followed to prepare for functional testing. This may include steps such as installing plugins or adding content to the dev site. -->

Follow the steps below to test the changes in this PR.

1. Deploy this branch to the `dev` environment.
2. Navigate to...
3. 

### Functional tests

<!-- Add the tests that should pass to approve functional testing. -->

As the functional tester for this pull request, I verify that:

- [ ] It [does something]
- [ ] it does not...
- [ ] As an admin, I can...
- [ ] As a user, I can...

Once testing is complete, notify the author of failed tests and move the task to "Kick back" in Asana. If all tests pass, move the task to "Ready for Code Review" in Asana and tag a team member for code review.

### Code review

As the code reviewer for this pull request, I verify that:

- [ ] All automated tests have passed.
- [ ] The code is written (or documented) in a way that is easy to understand.
- [ ] The code is free of obvious errors.
- [ ] The code is free of obvious duplication.
- [ ] The code follows our coding standards.
- [ ] The code is sanitized or escaped appropriately for any SQL or XSS injection possibilities.

Once testing is complete, notify the author of any failed tests and move the task to "Kick back" in Asana or continue with the "merging" steps below.

## Merging

As the individual merging this pull request, I verify that:

- [ ] All automated tests have passed.
- [ ] All functional tests have passed.
- [ ] All code review tests have passed.
- [ ] I have moved the task to "Ready to Deploy" in Asana and notified the pull request author.
